### PR TITLE
Rule curation

### DIFF
--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -8,26 +8,27 @@
     },
     {
       "category": "neg",
-      "literal": "adequate to rule her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "adequate to rule him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
       "literal": "adequate to rule out",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": "adequate"},
+        {"LOWER": "to"},
+        {"LOWER": "rule"},
+        {"LOWER": {"IN": ["him", "her", "them", "patient", "pt"]}, "OP": "?"},
+        {"LOWER": "out"}
+        ],
       "rule": "FORWARD"
     },
     {
       "category": "neg",
       "literal": "adequate to rule the patient out",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": "adequate"},
+        {"LOWER": "to"},
+        {"LOWER": "rule"},
+        {"LOWER": "the"},
+        {"LOWER": {"IN": ["patient", "pt"]}},
+        {"LOWER": "out"}
+        ],
       "rule": "FORWARD"
     },
     {
@@ -63,229 +64,13 @@
     {
       "category": "neg",
       "literal": "as a cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary origin for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a secondary source of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as a source of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an origin for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary origin for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an secondary source of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as an source of",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": "as"},
+        {"LOWER": {"IN": ["a", "an", "the"]}},
+        {"LOWER": "secondary", "OP": "?"},
+        {"LOWER": {"IN": ["cause", "etiology", "source", "reason"]}},
+        {"LOWER": {"IN": ["for", "of"]}}
+        ],
       "rule": "TERMINATE"
     },
     {
@@ -299,126 +84,6 @@
       "literal": "as needed",
       "pattern": null,
       "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "as the cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the origin for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary origin for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the secondary source of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "as the source of",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "neg",
@@ -1035,31 +700,33 @@
     {
       "category": "poss",
       "literal": "may be ruled out",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": {"IN": ["may", "might"]}},
+        {"LOWER": "be"},
+        {"LOWER": "ruled"},
+        {"LOWER": "out"}
+        ],
       "rule": "BACKWARD"
     },
     {
       "category": "poss",
       "literal": "may be ruled out for",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": {"IN": ["may", "might"]}},
+        {"LOWER": "be"},
+        {"LOWER": "ruled"},
+        {"LOWER": "out"},
+        {"LOWER": "for"}
+        ],
       "rule": "FORWARD"
     },
     {
       "category": "poss",
       "literal": "might be",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "poss",
-      "literal": "might be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "poss",
-      "literal": "might be ruled out for",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": {"IN": ["may", "might"]}},
+        {"LOWER": "be"}
+        ]
       "rule": "FORWARD"
     },
     {
@@ -2013,25 +1680,12 @@
     {
       "category": "neg",
       "literal": "without any evidence of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "without evidence",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "without indication of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "without sign of",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": "without"},
+        {"LOWER": "any", "OP": "?"},
+        {"LOWER": {"IN": ["evidence", "indication", "sign"]}},
+        {"LOWER": {"IN": ["of", "for"]}, "OP":"?"}
+        ],
       "rule": "FORWARD"
     },
     {

--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -549,7 +549,11 @@
       "category": "NEGATED_EXISTENCE",
       "literal": "lacked",
       "pattern": [
-        {"LOWER": {"IN": ["lacked", "lacking"]}}
+        {
+          "LOWER": {
+            "IN": ["lacked", "lacking"]
+          }
+        }
       ],
       "rule": "FORWARD"
     },
@@ -744,7 +748,9 @@
       "literal": "not significant",
       "pattern": [
         {
-          "LOWER": {"IN": ["not", "n't"]}
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
         },
         {
           "LOWER": {
@@ -783,10 +789,16 @@
       "literal": "not associated with",
       "pattern": [
         {
-          "LOWER": {"IN": ["not", "n't"]}
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
         },
-        {"LOWER": "associated"},
-        {"LOWER": "with"}
+        {
+          "LOWER": "associated"
+        },
+        {
+          "LOWER": "with"
+        }
       ],
       "rule": "FORWARD"
     },
@@ -928,7 +940,9 @@
       "literal": "is to be ruled out",
       "pattern": [
         {
-          "LOWER": {"IN": ["is", "ought"]}
+          "LOWER": {
+            "IN": ["is", "ought"]
+          }
         },
         {
           "LOWER": "to"
@@ -973,13 +987,19 @@
       "literal": "patient was not",
       "pattern": [
         {
-          "LOWER": {"IN": ["patient", "pt"]}
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
         },
         {
-          "LOWER": {"IN": ["was", "is"]}
+          "LOWER": {
+            "IN": ["was", "is"]
+          }
         },
         {
-          "LOWER": {"IN": ["not", "n't"]}
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
         }
       ],
       "rule": "FORWARD"

--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -980,7 +980,7 @@
         },
         {
           "LOWER": {"IN": ["not", "n't"]}
-        },
+        }
       ],
       "rule": "FORWARD"
     },

--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -1058,7 +1058,7 @@
       "pattern": [
         {
           "LOWER": {
-            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+            "IN": ["may", "might", "must", "should", "will", "could"]
           },
           "OP": "?"
         },
@@ -1089,7 +1089,7 @@
       "pattern": [
         {
           "LOWER": {
-            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+            "IN": ["may", "might", "must", "should", "will", "could"]
           },
           "OP": "?"
         },

--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -1,290 +1,384 @@
 {
   "item_data": [
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "absence of",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "adequate to rule out",
       "pattern": [
-        {"LOWER": "adequate"},
-        {"LOWER": "to"},
-        {"LOWER": "rule"},
-        {"LOWER": {"IN": ["him", "her", "them", "patient", "pt"]}, "OP": "?"},
-        {"LOWER": "out"}
-        ],
+        {
+          "LOWER": {
+            "IN": ["adequate", "sufficient"]
+          }
+        },
+        {
+          "LOWER": "to"
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": {
+            "IN": ["him", "her", "them", "patient", "pt"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "adequate to rule the patient out",
       "pattern": [
-        {"LOWER": "adequate"},
-        {"LOWER": "to"},
-        {"LOWER": "rule"},
-        {"LOWER": "the"},
-        {"LOWER": {"IN": ["patient", "pt"]}},
-        {"LOWER": "out"}
-        ],
+        {
+          "LOWER": {
+            "IN": ["adequate", "sufficient"]
+          }
+        },
+        {
+          "LOWER": "to"
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": "the"
+        },
+        {
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": "against",
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "although",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "any other",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "apart from",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "are negative",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "are ruled out",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["are", "is", "was"]
+          }
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        }
+      ],
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "as a cause for",
       "pattern": [
-        {"LOWER": "as"},
-        {"LOWER": {"IN": ["a", "an", "the"]}},
-        {"LOWER": "secondary", "OP": "?"},
-        {"LOWER": {"IN": ["cause", "etiology", "source", "reason"]}},
-        {"LOWER": {"IN": ["for", "of"]}}
-        ],
+        {
+          "LOWER": "as"
+        },
+        {
+          "LOWER": {
+            "IN": ["a", "an", "the"]
+          }
+        },
+        {
+          "LOWER": "secondary",
+          "OP": "?"
+        },
+        {
+          "LOWER": {
+            "IN": ["cause", "etiology", "source", "reason"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "of"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "as has",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "as needed",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "as well as any",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "aside from",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "aunt",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "aunt's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "because",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "being ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "brother",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "brother's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "but",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "can be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "can be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule her out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule her out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule her out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule him out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule him out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule him out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule out",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["can", "did"]
+          }
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": {
+            "IN": ["him", "her", "them", "patient", "pt"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "can rule out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "can rule out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "can rule the patient out",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "can"
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": "the"
+        },
+        {
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "can rule the patinet out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "can rule the patinet out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "cannot",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "cause for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "cause of",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "causes for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "causes of",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "checked for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "clear of",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "come back for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "come back to",
       "pattern": null,
       "rule": "FORWARD"
@@ -296,25 +390,25 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "concerned about",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "concerning for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "could be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "could be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
@@ -326,259 +420,187 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "dad",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "dad's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "daughter",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "declined",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "declines",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "denied",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "denies",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "denying",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "did not rule out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
-      "literal": "did rule her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule her out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule him out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule him out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule the patient out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule the patient out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "did rule the patient out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "doesn't look like",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "doubt",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "ED",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "emergency department",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "etiology for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "etiology of",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "evaluate for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "except",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "fails to reveal",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "family",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "fam hx",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "father",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "father's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "free",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "free of",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "grandfather",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "grandfather's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "grandmother",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "grandmother's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "has been negative",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "has been ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "have been ruled out",
       "pattern": null,
       "rule": "BACKWARD"
@@ -596,411 +618,388 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "history",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "however",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "h/o",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "ho",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "hx",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "if",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "inconsistent with",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "is not",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "is ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "is to be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "is to be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "is negative",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "is neg",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "isn't",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "lack of",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "lacked",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "likely",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "may be ruled out",
       "pattern": [
-        {"LOWER": {"IN": ["may", "might"]}},
-        {"LOWER": "be"},
-        {"LOWER": "ruled"},
-        {"LOWER": "out"}
-        ],
+        {
+          "LOWER": {
+            "IN": ["may", "might"]
+          }
+        },
+        {
+          "LOWER": "be"
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        }
+      ],
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "may be ruled out for",
       "pattern": [
-        {"LOWER": {"IN": ["may", "might"]}},
-        {"LOWER": "be"},
-        {"LOWER": "ruled"},
-        {"LOWER": "out"},
-        {"LOWER": "for"}
-        ],
+        {
+          "LOWER": {
+            "IN": ["may", "might"]
+          }
+        },
+        {
+          "LOWER": "be"
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": "for"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "might be",
       "pattern": [
-        {"LOWER": {"IN": ["may", "might"]}},
-        {"LOWER": "be"}
-        ]
+        {
+          "LOWER": {
+            "IN": ["may", "might"]
+          }
+        },
+        {
+          "LOWER": "be"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "mom",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "mom's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "mother",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "mother's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "must be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "must be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "negative for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "never developed",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "never"
+        },
+        {
+          "LOWER": {
+            "IN": ["developed", "had"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "never had",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "nevertheless",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
-      "literal": "no abnormal",
-      "pattern": null,
+      "category": "NEGATED_EXISTENCE",
+      "literal": "no",
+      "pattern": [
+        {
+          "LOWER": "no"
+        },
+        {
+          "LOWER": {
+            "IN": ["abnormal", "new"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "no cause of",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "no"
+        },
+        {
+          "LOWER": {
+            "IN": ["cause", "history", "findings", "complaints", "sign", "signs", "suggestion"]
+          }
+        },
+        {
+          "LOWER": "of"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "no complaints of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no findings of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "no findings to indicate",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "no history of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "no longer present",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
-      "literal": "no mammographic evidence of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no new",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "no new evidence",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "no"
+        },
+        {
+          "LOWER": {
+            "IN": ["new", "other"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": {
+            "IN": ["mammographic", "radiographic"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "evidence"
+        },
+        {
+          "LOWER": {
+            "IN": ["of", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "no other evidence",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no radiographic evidence of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no sign( of)?",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "no significant",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "no"
+        },
+        {
+          "LOWER": {
+            "IN": ["significant", "suspicious"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "no signs of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no suggestion of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "no suspicious",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "non diagnostic",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "not"
+        },
+        {
+          "LOWER": {
+            "IN": ["appear", "appreciate", "demonstrate", "exhibit", "feel", "had", "have", "reveal", "see"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "not appear",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "not appreciate",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not associated with",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "not been ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not complain of",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "not"
+        },
+        {
+          "LOWER": {
+            "IN": ["complain", "know"]
+          }
+        },
+        {
+          "LOWER": "of"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "not demonstrate",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "not exhibit",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "not feel",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "not had",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "not have",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not have evidence of",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "not know of",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not known to have",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "not reveal",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "not ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
-      "literal": "not see",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "not to be",
       "pattern": null,
       "rule": "FORWARD"
@@ -1012,61 +1011,54 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "now resolved",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "origin for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["origin", "origins"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["of", "for"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
-      "literal": "origin of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "origins for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "origins of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "other possibilities of",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "ought to be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "ought to be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "past history",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hist",
+      "category": "HISTORICAL",
       "literal": "past medical history",
       "pattern": null,
       "rule": "FORWARD"
@@ -1078,7 +1070,7 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "patient was not",
       "pattern": null,
       "rule": "FORWARD"
@@ -1090,13 +1082,13 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
-      "literal": "possible",
+      "category": "POSSIBLE_EXISTENCE",
+      "literal": "poss",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "poss",
       "pattern": null,
       "rule": "FORWARD"
@@ -1114,49 +1106,49 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "probable",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "prophylaxis",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "r/o",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rather than",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "reason for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "reason of",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "reasons for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "reasons of",
       "pattern": null,
       "rule": "TERMINATE"
@@ -1174,285 +1166,293 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "resolved",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "return",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "ro",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule her out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule her out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule him out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule him out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule the patient out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule the patinet out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled her out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled her out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled her out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled him out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled him out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled him out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled the patient out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled the patient out against",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "ruled the patient out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules her out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules her out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules him out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules him out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules the patient out",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "rules the patient out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "secondary",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "secondary to",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "should be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "should be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "should he",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "should"
+        },
+        {
+          "LOWER": {
+            "IN": ["she", "he", "they", "patient", "pt"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
-      "literal": "should she",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "should the patient",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "should"
+        },
+        {
+          "LOWER": "the"
+        },
+        {
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "should there",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "hypo",
+      "category": "HYPOTHETICAL",
       "literal": "since",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "sister",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "sister's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "son",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "source for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "source of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "sources for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "neg",
-      "literal": "sources of",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["source", "sources"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "of"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
     },
     {
@@ -1462,109 +1462,37 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "still",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
-      "literal": "sufficient to rule her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule her out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule him out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule him out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule the patient out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule the patient out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "neg",
-      "literal": "sufficient to rule the patient out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "suggest(ive of)?",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "suspicious for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "test for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "though",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "to exclude",
       "pattern": null,
       "rule": "FORWARD"
@@ -1576,31 +1504,31 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "trigger event for",
       "pattern": null,
       "rule": "TERMINATE"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "uncle",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "uncle's",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "unlikely",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "unremarkable for",
       "pattern": null,
       "rule": "FORWARD"
@@ -1612,37 +1540,31 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "was negative",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "was not",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
-      "literal": "was ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "wasn't",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "what must be ruled out is",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "exp",
+      "category": "FAMILY",
       "literal": "which",
       "pattern": null,
       "rule": "TERMINATE"
@@ -1654,54 +1576,68 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "will be ruled out",
       "pattern": null,
       "rule": "BACKWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "will be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "with no",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "without",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "without any evidence of",
       "pattern": [
-        {"LOWER": "without"},
-        {"LOWER": "any", "OP": "?"},
-        {"LOWER": {"IN": ["evidence", "indication", "sign"]}},
-        {"LOWER": {"IN": ["of", "for"]}, "OP":"?"}
-        ],
+        {
+          "LOWER": "without"
+        },
+        {
+          "LOWER": "any",
+          "OP": "?"
+        },
+        {
+          "LOWER": {
+            "IN": ["evidence", "indication", "sign"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["of", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "worrisome for",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "poss",
+      "category": "POSSIBLE_EXISTENCE",
       "literal": "worried about",
       "pattern": null,
       "rule": "FORWARD"
     },
     {
-      "category": "neg",
+      "category": "NEGATED_EXISTENCE",
       "literal": "yet",
       "pattern": null,
       "rule": "TERMINATE"

--- a/kb/default_rules.json
+++ b/kb/default_rules.json
@@ -66,17 +66,13 @@
           "LOWER": "out"
         },
         {
-          "LOWER": "against",
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
           "OP": "?"
         }
       ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "although",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -87,14 +83,17 @@
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "apart from",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "apart"
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "from"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "are negative",
-      "pattern": null,
-      "rule": "BACKWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -169,105 +168,93 @@
     },
     {
       "category": "FAMILY",
-      "literal": "aunt",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "aunt's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "be ruled out for",
-      "pattern": null,
+      "literal": "family",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": [
+              "aunt",
+              "aunts",
+              "brother",
+              "brothers",
+              "child",
+              "children",
+              "cousin",
+              "cousins",
+              "dad",
+              "dads",
+              "daughter",
+              "daughters",
+              "fam",
+              "family",
+              "families",
+              "father",
+              "fathers",
+              "grandchild",
+              "grandchildren",
+              "granddaughter",
+              "granddaughters",
+              "grandfather",
+              "grandfathers",
+              "grandmother",
+              "grandmothers",
+              "grandparent",
+              "grandparents",
+              "grandson",
+              "grandsons",
+              "mom",
+              "moms",
+              "mother",
+              "mothers",
+              "nephew",
+              "nephews",
+              "niece",
+              "nieces",
+              "parent",
+              "parents",
+              "sibling",
+              "siblings",
+              "sister",
+              "sisters",
+              "son",
+              "sons",
+              "uncle",
+              "uncles"
+            ]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["'s", "'"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "HYPOTHETICAL",
       "literal": "because",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["because", "since"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "being ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "brother",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "brother's",
-      "pattern": null,
-      "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "but",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["but", "however", "nevertheless", "still", "except", "though", "although", "yet"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "can be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "can be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule her out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule him out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "can rule him out for",
-      "pattern": null,
-      "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -304,7 +291,9 @@
       "literal": "can rule the patient out",
       "pattern": [
         {
-          "LOWER": "can"
+          "LOWER": {
+            "IN": ["can", "did"]
+          }
         },
         {
           "LOWER": "rule"
@@ -331,32 +320,19 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "cannot",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
       "literal": "cause for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "cause of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "causes for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "causes of",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["cause", "causes", "reason", "reasons", "etiology"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "of"]
+          }
+        }
+      ],
       "rule": "TERMINATE"
     },
     {
@@ -374,109 +350,106 @@
     {
       "category": "HYPOTHETICAL",
       "literal": "come back for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "come"
+        },
+        {
+          "LOWER": "back"
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "to"]
+          }
+        }
+      ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "HYPOTHETICAL",
-      "literal": "come back to",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "histexp",
-      "literal": "complains",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
       "literal": "concerned about",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "concerning for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "could be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "could be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "histexp",
-      "literal": "currently",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "dad",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "dad's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "daughter",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["concerned", "concerning"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "about"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "declined",
-      "pattern": null,
+      "literal": "decline",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["decline", "declined", "declines", "declining"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "declines",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "denied",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "denies",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "denying",
-      "pattern": null,
+      "literal": "deny",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["deny", "denied", "denies", "denying"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
       "literal": "did not rule out",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["did", "could"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": "out"
+        }
+      ],
       "rule": "BACKWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "doesn't look like",
-      "pattern": null,
+      "literal": "does not look like",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["does", "did"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "look"
+        },
+        {
+          "LOWER": "like"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
@@ -486,30 +459,6 @@
       "rule": "FORWARD"
     },
     {
-      "category": "HISTORICAL",
-      "literal": "ED",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "HISTORICAL",
-      "literal": "emergency department",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "etiology for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "etiology of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
       "category": "NEGATED_EXISTENCE",
       "literal": "evaluate for",
       "pattern": null,
@@ -517,37 +466,7 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "except",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
       "literal": "fails to reveal",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "family",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "fam hx",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "father",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "father's",
       "pattern": null,
       "rule": "FORWARD"
     },
@@ -564,30 +483,6 @@
       "rule": "FORWARD"
     },
     {
-      "category": "FAMILY",
-      "literal": "grandfather",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "grandfather's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "grandmother",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "grandmother's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
       "category": "NEGATED_EXISTENCE",
       "literal": "has been negative",
       "pattern": null,
@@ -596,54 +491,39 @@
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "has been ruled out",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["has", "have"]
+          }
+        },
+        {
+          "LOWER": "been"
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        }
+      ],
       "rule": "BACKWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "have been ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "hypoexp",
-      "literal": "her",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "hypoexp",
-      "literal": "his",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "HISTORICAL",
       "literal": "history",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["history", "hx", "hist", "ho"]
+          }
+        }
+      ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "however",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "HISTORICAL",
       "literal": "h/o",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "HISTORICAL",
-      "literal": "ho",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "HISTORICAL",
-      "literal": "hx",
       "pattern": null,
       "rule": "FORWARD"
     },
@@ -661,42 +541,6 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "is not",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "is to be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "is to be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "is negative",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "is neg",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "isn't",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
       "literal": "lack of",
       "pattern": null,
       "rule": "FORWARD"
@@ -704,13 +548,9 @@
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "lacked",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "likely",
-      "pattern": null,
+      "pattern": [
+        {"LOWER": {"IN": ["lacked", "lacking"]}}
+      ],
       "rule": "FORWARD"
     },
     {
@@ -719,8 +559,9 @@
       "pattern": [
         {
           "LOWER": {
-            "IN": ["may", "might"]
-          }
+            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+          },
+          "OP": "?"
         },
         {
           "LOWER": "be"
@@ -740,8 +581,9 @@
       "pattern": [
         {
           "LOWER": {
-            "IN": ["may", "might"]
-          }
+            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+          },
+          "OP": "?"
         },
         {
           "LOWER": "be"
@@ -774,50 +616,23 @@
       "rule": "FORWARD"
     },
     {
-      "category": "FAMILY",
-      "literal": "mom",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "mom's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "mother",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "mother's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "must be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "must be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
       "category": "NEGATED_EXISTENCE",
       "literal": "negative for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["negative", "neg"]
+          }
+        },
+        {
+          "LOWER": "for"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "never developed",
+      "literal": "never had",
       "pattern": [
         {
           "LOWER": "never"
@@ -829,12 +644,6 @@
         }
       ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "nevertheless",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -865,7 +674,9 @@
           }
         },
         {
-          "LOWER": "of"
+          "LOWER": {
+            "IN": ["of", "for"]
+          }
         }
       ],
       "rule": "FORWARD"
@@ -884,7 +695,7 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "no new evidence",
+      "literal": "no evidence",
       "pattern": [
         {
           "LOWER": "no"
@@ -930,6 +741,21 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
+      "literal": "not significant",
+      "pattern": [
+        {
+          "LOWER": {"IN": ["not", "n't"]}
+        },
+        {
+          "LOWER": {
+            "IN": ["significant", "suspicious"]
+          }
+        }
+      ],
+      "rule": "BACKWARD"
+    },
+    {
+      "category": "NEGATED_EXISTENCE",
       "literal": "non diagnostic",
       "pattern": null,
       "rule": "BACKWARD"
@@ -939,7 +765,9 @@
       "literal": "not",
       "pattern": [
         {
-          "LOWER": "not"
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
         },
         {
           "LOWER": {
@@ -953,13 +781,35 @@
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "not associated with",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {"IN": ["not", "n't"]}
+        },
+        {"LOWER": "associated"},
+        {"LOWER": "with"}
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
-      "literal": "not been ruled out",
-      "pattern": null,
+      "literal": "not ruled out",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "been",
+          "OP": "?"
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        }
+      ],
       "rule": "BACKWARD"
     },
     {
@@ -967,7 +817,9 @@
       "literal": "not complain of",
       "pattern": [
         {
-          "LOWER": "not"
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
         },
         {
           "LOWER": {
@@ -983,32 +835,64 @@
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "not have evidence of",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "have"
+        },
+        {
+          "LOWER": "evidence"
+        },
+        {
+          "LOWER": {
+            "IN": ["of", "for"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "not known to have",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "known"
+        },
+        {
+          "LOWER": "to"
+        },
+        {
+          "LOWER": "have"
+        }
+      ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "not ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "not to be",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        },
+        {
+          "LOWER": "to"
+        },
+        {
+          "LOWER": "be"
+        }
+      ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "histexp",
-      "literal": "noted",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -1041,74 +925,75 @@
     },
     {
       "category": "POSSIBLE_EXISTENCE",
-      "literal": "ought to be ruled out",
-      "pattern": null,
+      "literal": "is to be ruled out",
+      "pattern": [
+        {
+          "LOWER": {"IN": ["is", "ought"]}
+        },
+        {
+          "LOWER": "to"
+        },
+        {
+          "LOWER": "be"
+        },
+        {
+          "LOWER": "ruled"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["for", "against"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "ought to be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
     },
     {
       "category": "HISTORICAL",
       "literal": "past history",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": "past"
+        },
+        {
+          "LOWER": "medical",
+          "OP": "?"
+        },
+        {
+          "LOWER": "history"
+        }
+      ],
       "rule": "FORWARD"
-    },
-    {
-      "category": "HISTORICAL",
-      "literal": "past medical history",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "hypoexp",
-      "literal": "patient",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "patient was not",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "hypoexp",
-      "literal": "patient's",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "poss",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {"IN": ["patient", "pt"]}
+        },
+        {
+          "LOWER": {"IN": ["was", "is"]}
+        },
+        {
+          "LOWER": {"IN": ["not", "n't"]}
+        },
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
-      "literal": "poss",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "histexp",
-      "literal": "presenting",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "histexp",
-      "literal": "presents",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "probable",
-      "pattern": null,
+      "literal": "possible",
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["poss", "possible", "probably", "likely"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
@@ -1131,42 +1016,6 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "reason for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "reason of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "reasons for",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "reasons of",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "histexp",
-      "literal": "reported",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "histexp",
-      "literal": "reports",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
       "literal": "resolved",
       "pattern": null,
       "rule": "FORWARD"
@@ -1185,195 +1034,133 @@
     },
     {
       "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule him out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
       "literal": "rule out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule out for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": {
+            "IN": ["him", "her", "them", "patient", "pt"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
       "literal": "rule the patient out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "rule the patinet out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled her out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled him out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled him out for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["may", "might", "must", "should", "will", "could", "can"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "rule"
+        },
+        {
+          "LOWER": "the"
+        },
+        {
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "ruled out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled out for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["ruled", "rules"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["him", "her", "them", "patient", "pt"]
+          },
+          "OP": "?"
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "ruled the patient out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled the patient out against",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "ruled the patient out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules her out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules her out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules him out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules him out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules out for",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules the patient out",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "rules the patient out for",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["ruled", "rules"]
+          }
+        },
+        {
+          "LOWER": "the"
+        },
+        {
+          "LOWER": {
+            "IN": ["patient", "pt"]
+          }
+        },
+        {
+          "LOWER": "out"
+        },
+        {
+          "LOWER": {
+            "IN": ["against", "for"]
+          },
+          "OP": "?"
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "secondary",
-      "pattern": null,
+      "pattern": [{
+          "LOWER": "secondary"
+        }, {
+          "LOWER": "to", "OP": "?"
+        }],
       "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "secondary to",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "should be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "should be ruled out for",
-      "pattern": null,
-      "rule": "FORWARD"
     },
     {
       "category": "HYPOTHETICAL",
@@ -1415,30 +1202,6 @@
       "rule": "FORWARD"
     },
     {
-      "category": "HYPOTHETICAL",
-      "literal": "since",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "sister",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "sister's",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "son",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
       "category": "NEGATED_EXISTENCE",
       "literal": "source for",
       "pattern": [
@@ -1456,20 +1219,8 @@
       "rule": "TERMINATE"
     },
     {
-      "category": "histexp",
-      "literal": "states",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "still",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
       "category": "POSSIBLE_EXISTENCE",
-      "literal": "suggest(ive of)?",
+      "literal": "suggestive of",
       "pattern": null,
       "rule": "FORWARD"
     },
@@ -1487,39 +1238,15 @@
     },
     {
       "category": "NEGATED_EXISTENCE",
-      "literal": "though",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
       "literal": "to exclude",
       "pattern": null,
       "rule": "FORWARD"
-    },
-    {
-      "category": "histexp",
-      "literal": "today",
-      "pattern": null,
-      "rule": "TERMINATE"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "trigger event for",
       "pattern": null,
       "rule": "TERMINATE"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "uncle",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "uncle's",
-      "pattern": null,
-      "rule": "FORWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
@@ -1534,56 +1261,42 @@
       "rule": "FORWARD"
     },
     {
-      "category": "histexp",
-      "literal": "was found",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
       "category": "NEGATED_EXISTENCE",
       "literal": "was negative",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["was", "is", "are"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["negative", "neg"]
+          }
+        }
+      ],
       "rule": "BACKWARD"
     },
     {
       "category": "NEGATED_EXISTENCE",
       "literal": "was not",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "wasn't",
-      "pattern": null,
+      "pattern": [
+        {
+          "LOWER": {
+            "IN": ["was", "is", "are", "can"]
+          }
+        },
+        {
+          "LOWER": {
+            "IN": ["not", "n't"]
+          }
+        }
+      ],
       "rule": "FORWARD"
     },
     {
       "category": "POSSIBLE_EXISTENCE",
       "literal": "what must be ruled out is",
-      "pattern": null,
-      "rule": "FORWARD"
-    },
-    {
-      "category": "FAMILY",
-      "literal": "which",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "hypoexp",
-      "literal": "who",
-      "pattern": null,
-      "rule": "TERMINATE"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "will be ruled out",
-      "pattern": null,
-      "rule": "BACKWARD"
-    },
-    {
-      "category": "POSSIBLE_EXISTENCE",
-      "literal": "will be ruled out for",
       "pattern": null,
       "rule": "FORWARD"
     },
@@ -1635,12 +1348,6 @@
       "literal": "worried about",
       "pattern": null,
       "rule": "FORWARD"
-    },
-    {
-      "category": "NEGATED_EXISTENCE",
-      "literal": "yet",
-      "pattern": null,
-      "rule": "TERMINATE"
     }
   ]
 }


### PR DESCRIPTION
Cleaned up rules and manually created patterns for most rules in the file. I collapsed rules using "IN" lists as often as possible, but tried not to collapse with the same phrase but slightly distinct meanings.

There are some redundant-looking rules due to no group-capture functionality in spacy patterns at the moment: "ruled out" vs "ruled _him_ out" vs "ruled _the patient_ out" are the most common due to the optional two-word phrase. Either both words need to appear or neither so that phrases like 'rule _the_ out' cannot be generated. It is possible these phrases will never occur in text and never cause issues, however I chose the tighter bounds of acceptable phrases rather than fewer rules.

No Lemmas were used, so that POS tagging is not a prerequisite of the default pipeline. This makes some rules look redundant when they contain multiple conjugations of one verb in a list. However, if lemmas are ever adopted we need to be careful because tense is often the difference between a negative/possible result: "_can_ rule out" vs "_could_ rule out"

**Known isssues:**
1. "Rule out" has a lot of phrasal variations by itself and there are A LOT of rules that use "rule out" in it. For example, this rule covers a variety of phrases roughly like "adequate to rule out" but it assumes that "rule out" is spelled out and not abbreviated as "ro" or "r/o". Perhaps for a future release, we break out these types of rules and create a separate json that can just exhaustively list all the "rule out" variants in the pattern. Then the "default" rules actually load more than one file on intialization. This might make it easier to read/iterate over time, since this file is already quite large.
```
{
      "category": "NEGATED_EXISTENCE",
      "literal": "adequate to rule out",
      "pattern": [
        {
          "LOWER": {
            "IN": ["adequate", "sufficient"]
          }
        },
        {
          "LOWER": "to"
        },
        {
          "LOWER": "rule"
        },
        {
          "LOWER": {
            "IN": ["him", "her", "them", "patient", "pt"]
          },
          "OP": "?"
        },
        {
          "LOWER": "out"
        },
        {
          "LOWER": {
            "IN": ["against", "for"]
          },
          "OP": "?"
        }
      ],
      "rule": "FORWARD"
    }
```

2. Typos more broadly are not accounted for.

3. Family tags are not very robust. Currently accepts all(?) one-word family member types, however we should consider renaming the FAMILY attribute to something more broad. It is acceptable to change who the experiencer is without the other party being a family member. Friends, coworkers, etc. all may be mentioned in notes and are currently unaccounted for.