### PR TITLE
Code Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # cycontext
 A Python implementation of the ConText algorithm for clinical text concept assertion using the spaCy framework
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 # Overview
 This package implements the ConText algorithm within the [spaCy](https://spacy.io) framework. 
 [ConText](https://www.sciencedirect.com/science/article/pii/S1532046409000744) detects semantic modifiers such as **negation**, 

--- a/cycontext/__init__.py
+++ b/cycontext/__init__.py
@@ -1,7 +1,4 @@
 from .context_component import ConTextComponent, DEFAULT_RULES_FILEPATH
 from .context_item import ConTextItem
 
-__all__ = ["ConTextComponent",
-           "ConTextItem",
-           "DEFAULT_RULES_FILEPATH"]
-
+__all__ = ["ConTextComponent", "ConTextItem", "DEFAULT_RULES_FILEPATH"]

--- a/cycontext/context_graph.py
+++ b/cycontext/context_graph.py
@@ -1,10 +1,8 @@
 class ConTextGraph:
-
     def __init__(self):
         self.targets = []
         self.modifiers = []
         self.edges = []
-
 
     def update_scopes(self):
         """For each modifier in a list of TagObjects,
@@ -64,7 +62,7 @@ class ConTextGraph:
         # Start by comparing modifiers against targets
         # Remove any modifiers which overlap with a target
         # Go backwards so we can remove modifiers which need to be pruned
-        for i in range(len(self.modifiers)-1, -1, -1):
+        for i in range(len(self.modifiers) - 1, -1, -1):
             modifier = self.modifiers[i]
             for target in self.targets:
                 if overlap_target_modifiers(target, modifier.span):
@@ -112,24 +110,20 @@ class ConTextGraph:
         # Recursion base point
         if len(pruned) == num_mods:
             return pruned
-        else:
-            return self.prune_overlapping_modifiers(pruned)
+        return self.prune_overlapping_modifiers(pruned)
 
     def __repr__(self):
-        return "<ConTextGraph> with {0} targets and {1} modifiers".format(len(self.targets), len(self.modifiers))
+        return "<ConTextGraph> with {0} targets and {1} modifiers".format(
+            len(self.targets), len(self.modifiers)
+        )
+
 
 def overlap_target_modifiers(span1, span2):
     """Checks whether two spacy spans overlap."""
-    if _spans_overlap(span1, span2):
-        return True
-    if _spans_overlap(span2, span1):
-        return True
-    return False
+    return _spans_overlap(span1, span2)
+
 
 def _spans_overlap(span1, span2):
-    if span1.end > span2.start and span1.end <= span2.end:
-        return True
-    if span1.start >= span2.start and span1.start < span2.end:
-        return True
-
-
+    return (span1.end > span2.start and span1.end <= span2.end) or (
+        span1.start >= span2.start and span1.start < span2.end
+    )

--- a/cycontext/context_item.py
+++ b/cycontext/context_item.py
@@ -1,11 +1,41 @@
+import json
+
+
 class ConTextItem:
     """An ConTextItem defines a ConText modifier. It defines the phrase to be matched,
     the category/semantic class, and the rule which the modifier executes.
     """
-    _ALLOWED_RULES = ("FORWARD", "BACKWARD", "BIDIRECTIONAL", "TERMINATE", "MAX_TARGETS", "MAX_SCOPE")
-    _ALLOWED_KEYS = {"literal", "rule", "pattern", "category", "metadata", "allowed_types", "filtered_types"}
-    def __init__(self, literal, category, rule="BIDIRECTIONAL", pattern=None, allowed_types=None, excluded_types=None,
-                 max_targets=None, max_scope=None, metadata=None):
+
+    _ALLOWED_RULES = (
+        "FORWARD",
+        "BACKWARD",
+        "BIDIRECTIONAL",
+        "TERMINATE",
+        "MAX_TARGETS",
+        "MAX_SCOPE",
+    )
+    _ALLOWED_KEYS = {
+        "literal",
+        "rule",
+        "pattern",
+        "category",
+        "metadata",
+        "allowed_types",
+        "filtered_types",
+    }
+
+    def __init__(
+        self,
+        literal,
+        category,
+        rule="BIDIRECTIONAL",
+        pattern=None,
+        allowed_types=None,
+        excluded_types=None,
+        max_targets=None,
+        max_scope=None,
+        metadata=None,
+    ):
         """Create an ConTextItem object.
 
         literal (str): The actual string of a concept. If pattern is None,
@@ -35,8 +65,10 @@ class ConTextItem:
         self.rule = rule.upper()
 
         if allowed_types is not None and excluded_types is not None:
-            raise ValueError("A ConTextItem was instantiated with non-null values for both allowed_types and excluded_types. "
-                             "Only one of these can be non-null, since cycontext either explicitly includes or excludes target types.")
+            raise ValueError(
+                "A ConTextItem was instantiated with non-null values for both allowed_types and excluded_types. "
+                "Only one of these can be non-null, since cycontext either explicitly includes or excludes target types."
+            )
         if allowed_types is not None:
             self.allowed_types = {label.upper() for label in allowed_types}
         else:
@@ -55,9 +87,12 @@ class ConTextItem:
 
         self.metadata = metadata
 
-
         if self.rule not in self._ALLOWED_RULES:
-            raise ValueError("Rule {0} not recognized. Must be one of: {1}".format(self.rule, self._ALLOWED_RULES))
+            raise ValueError(
+                "Rule {0} not recognized. Must be one of: {1}".format(
+                    self.rule, self._ALLOWED_RULES
+                )
+            )
 
     @classmethod
     def from_json(cls, filepath):
@@ -69,43 +104,57 @@ class ConTextItem:
         RAISES KeyError if the dictionary contains any keys other than
             those accepted by ConTextItem.__init__
         """
-        import json
-        with open(filepath) as f:
-            modifier_data = json.load(f)
+
+        with open(filepath) as file:
+            modifier_data = json.load(file)
         item_data = []
         for data in modifier_data["item_data"]:
             item_data.append(ConTextItem.from_dict(data))
         return item_data
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, item_dict):
+        """Reads a dictionary into a ConTextItem. Used when reading from a json file.
+
+        item_dict (dictionary): the dictionary to convert
+
+        RETURNS item (ConTextItem): the ConTextItem created from the dictionary
+        """
         try:
-            item = ConTextItem(**d)
+            item = ConTextItem(**item_dict)
         except TypeError:
-            keys = set(d.keys())
+            keys = set(item_dict.keys())
             invalid_keys = keys.difference(cls._ALLOWED_KEYS)
-            msg = ("JSON object contains invalid keys: {0}.\n"
-                   "Must be one of: {1}".format(invalid_keys, cls._ALLOWED_KEYS))
+            msg = (
+                "JSON object contains invalid keys: {0}.\n"
+                "Must be one of: {1}".format(invalid_keys, cls._ALLOWED_KEYS)
+            )
             raise ValueError(msg)
 
         return item
 
     @classmethod
     def to_json(cls, item_data, filepath):
-        import json
+        """
+        Writes ConTextItems to a json file.
+
+        item_data (ConTextItem): a list of ConTextItems that will be written to a file.
+        filepath (text): the .json file to contain modifier rules
+        """
+
         data = {"item_data": [item.to_dict() for item in item_data]}
-        with open(filepath, "w") as f:
-            json.dump(data, f, indent=4)
+        with open(filepath, "w") as file:
+            json.dump(data, file, indent=4)
 
     def to_dict(self):
-        d = {}
+        """Converts ConTextItems to a python dictionary. Used when writing context items to a json file.
+
+        RETURNS item_dict (dictionary): the dictionary containing the ConTextItem info.
+        """
+        item_dict = {}
         for key in self._ALLOWED_KEYS:
-            d[key] = self.__dict__.get(key)
-        return d
+            item_dict[key] = self.__dict__.get(key)
+        return item_dict
 
     def __repr__(self):
         return f"ConTextItem(literal='{self.literal}', category='{self.category}', pattern={self.pattern}, rule='{self.rule}')"
-
-
-
-

--- a/cycontext/helpers.py
+++ b/cycontext/helpers.py
@@ -2,39 +2,6 @@
 which will be done in conjunction with cycontext.
 """
 
-class PunktSentencizer:
-    def __init__(self):
-        from nltk.tokenize import PunktSentenceTokenizer
-        self.tokenizer = PunktSentenceTokenizer()
-
-    def __call__(self, doc):
-        sent_spans = self.tokenizer.span_tokenize(doc.text)
-        for token in doc:
-            token.is_sent_start = False
-        for (start, end) in sent_spans:
-            sent = doc.char_span(start, end)
-            sent[0].is_sent_start = True
-        return doc
-
-
-
-
-
-class PyRuSHSentencizer:
-    def __init__(self, rules_path):
-        from PyRuSH.RuSH import RuSH
-        self.rules_path = rules_path
-        self.rush = RuSH(self.rules_path)
-
-    def __call__(self, doc):
-        for token in doc:
-            token.is_sent_start = False
-        sentence_spans = self.rush.segToSentenceSpans(doc.text)
-        for span in sentence_spans:
-            sent = doc.char_span(span.begin, span.end)
-            sent[0].is_sent_start = True
-        return doc
-
 def is_modified_by(span, modifier_label):
     for modifier in span._.modifiers:
         if modifier.category.upper() == modifier_label.upper():

--- a/cycontext/viz.py
+++ b/cycontext/viz.py
@@ -1,5 +1,6 @@
 from spacy import displacy
 
+
 def visualize_ent(doc, colors=None):
     """Create a NER-style visualization
     for targets and modifiers in Doc.
@@ -13,16 +14,22 @@ def visualize_ent(doc, colors=None):
 
     modifier_start_chars = set()
     for target in doc.ents:
-        ents_data.append({"start": target.start_char, "end":  target.end_char, "label": target.label_})
+        ents_data.append(
+            {"start": target.start_char, "end": target.end_char, "label": target.label_}
+        )
     for _, modifier in doc._.context_graph.edges:
         if modifier.span.start_char not in modifier_start_chars:
-            ents_data.append({"start": modifier.span.start_char, "end": modifier.span.end_char, "label": modifier.category})
+            ents_data.append(
+                {
+                    "start": modifier.span.start_char,
+                    "end": modifier.span.end_char,
+                    "label": modifier.category,
+                }
+            )
             modifier_start_chars.add(modifier.span.start_char)
     ents_data = sorted(ents_data, key=lambda x: x["start"])
 
-    viz_data = [{"text": doc.text,
-                "ents": ents_data,
-                }]
+    viz_data = [{"text": doc.text, "ents": ents_data,}]
     if colors is None:
         labels = set()
         for target in doc._.context_graph.targets:
@@ -30,9 +37,11 @@ def visualize_ent(doc, colors=None):
         for modifier in doc._.context_graph.modifiers:
             labels.add(modifier.category.upper())
         colors = _create_color_mapping(labels)
-    options = {"colors": colors,
-              }
+    options = {
+        "colors": colors,
+    }
     displacy.render(viz_data, style="ent", manual=True, options=options)
+
 
 def _create_color_mapping(labels):
     mapping = {}
@@ -42,12 +51,25 @@ def _create_color_mapping(labels):
             mapping[label] = next(color_cycle)
     return mapping
 
+
 def _create_color_generator():
     """Create a generator which will cycle through a list of default matplotlib colors"""
     from itertools import cycle
-    colors = [u'#1f77b4', u'#ff7f0e', u'#2ca02c', u'#d62728',
-              u'#9467bd', u'#8c564b', u'#e377c2', u'#7f7f7f', u'#bcbd22', u'#17becf']
+
+    colors = [
+        u"#1f77b4",
+        u"#ff7f0e",
+        u"#2ca02c",
+        u"#d62728",
+        u"#9467bd",
+        u"#8c564b",
+        u"#e377c2",
+        u"#7f7f7f",
+        u"#bcbd22",
+        u"#17becf",
+    ]
     return cycle(colors)
+
 
 def visualize_dep(doc):
     """Create a dependency-style visualization for
@@ -78,11 +100,10 @@ def visualize_dep(doc):
             token_data.pop(idx + 1)
 
         # Lower the index of the following tokens
-        for other_data in token_data[idx+1:]:
+        for other_data in token_data[idx + 1 :]:
             other_data["index"] -= len(span) - 1
 
-    dep_data = {"words": token_data,
-               "arcs": []}
+    dep_data = {"words": token_data, "arcs": []}
     # Gather the edges between targets and modifiers
     for target, modifier in doc._.context_graph.edges:
         target_data = token_data_mapping[target[0]]
@@ -92,8 +113,7 @@ def visualize_dep(doc):
                 "start": min(target_data["index"], modifier_data["index"]),
                 "end": max(target_data["index"], modifier_data["index"]),
                 "label": modifier.category,
-                "dir": "right" if target > modifier.span else "left"
+                "dir": "right" if target > modifier.span else "left",
             }
         )
     displacy.render(dep_data, manual=True)
-    return

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,20 @@ from setuptools import setup
 
 # read the contents of the README file
 from os import path
+
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-setup(name='cycontext',
-      version='0.1.5',
-      description='ConText algorithm using spaCy for clinical NLP',
-      author='Alec Chapman',
-      author_email='abchapman93@gmail.com',
-      packages=['cycontext'],
-      install_requires=["spacy>=2.2.2"],
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      package_data={'cycontext': ['../kb/*']},
-      )
+setup(
+    name="cycontext",
+    version="0.1.5",
+    description="ConText algorithm using spaCy for clinical NLP",
+    author="Alec Chapman",
+    author_email="abchapman93@gmail.com",
+    packages=["cycontext"],
+    install_requires=["spacy>=2.2.2"],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    package_data={"cycontext": ["../kb/*"]},
+)

--- a/tests/test_context_component.py
+++ b/tests/test_context_component.py
@@ -7,11 +7,10 @@ from cycontext import ConTextItem
 import pytest
 
 
-
 nlp = spacy.load("en_core_web_sm")
 
-class TestConTextComponent:
 
+class TestConTextComponent:
     def test_initiate(self):
         assert ConTextComponent(nlp)
 
@@ -27,30 +26,32 @@ class TestConTextComponent:
 
     def test_custom_patterns_json(self):
         """Test that rules are loaded from a json"""
-        context = ConTextComponent(nlp, rules='other', rule_list='./kb/default_rules.json')
+        context = ConTextComponent(
+            nlp, rules="other", rule_list="./kb/default_rules.json"
+        )
         assert context.item_data
 
     def test_custom_patterns_list(self):
         """Test that rules are loaded from a list"""
         item = ConTextItem("evidence of", "DEFINITE_EXISTENCE", "forward")
-        context = ConTextComponent(nlp, rules='other', rule_list=[item])
+        context = ConTextComponent(nlp, rules="other", rule_list=[item])
         assert context.item_data
 
     def test_bad_rules_arg(self):
         with pytest.raises(ValueError):
-            ConTextComponent(nlp, rules='not valid')
+            ConTextComponent(nlp, rules="not valid")
 
     def test_bad_rule_list_path(self):
         with pytest.raises(ValueError):
-            ConTextComponent(nlp, rules='other', rule_list='not a path')
+            ConTextComponent(nlp, rules="other", rule_list="not a path")
 
     def test_bad_rule_list_empty(self):
         with pytest.raises(ValueError):
-            ConTextComponent(nlp, rules='other', rule_list=[])
+            ConTextComponent(nlp, rules="other", rule_list=[])
 
     def test_bad_rule_list_items(self):
         with pytest.raises(ValueError):
-            ConTextComponent(nlp, rules='other', rule_list=["list of strings"])
+            ConTextComponent(nlp, rules="other", rule_list=["list of strings"])
 
     def test_call(self):
         doc = nlp("Pulmonary embolism has been ruled out.")
@@ -61,7 +62,7 @@ class TestConTextComponent:
     def test_registers_attributes(self):
         """Test that the default ConText attributes are set on ."""
         doc = nlp("There is consolidation.")
-        doc.ents = (doc[-2:-1], )
+        doc.ents = (doc[-2:-1],)
         context = ConTextComponent(nlp)
         doc = context(doc)
         assert hasattr(doc._, "context_graph")
@@ -75,7 +76,13 @@ class TestConTextComponent:
         context = ConTextComponent(nlp, add_attrs=True, rules=None)
         context(doc)
         span = doc[-2:]
-        for attr_name in ["is_negated", "is_uncertain", "is_historical", "is_hypothetical", "is_family"]:
+        for attr_name in [
+            "is_negated",
+            "is_uncertain",
+            "is_historical",
+            "is_hypothetical",
+            "is_family",
+        ]:
             assert hasattr(span._, attr_name)
 
     def test_default_attribute_values(self):
@@ -84,7 +91,13 @@ class TestConTextComponent:
         context = ConTextComponent(nlp, add_attrs=True, rules=None)
         doc.ents = (doc[-2:-1],)
         context(doc)
-        for attr_name in ["is_negated", "is_uncertain", "is_historical", "is_hypothetical", "is_family"]:
+        for attr_name in [
+            "is_negated",
+            "is_uncertain",
+            "is_historical",
+            "is_hypothetical",
+            "is_family",
+        ]:
             assert getattr(doc.ents[0]._, attr_name) is False
 
     def test_default_rules_match(self):
@@ -94,10 +107,9 @@ class TestConTextComponent:
 
     def test_custom_rules_match(self):
         item = ConTextItem("no evidence of", "NEGATED_EXISTENCE", "forward")
-        context = ConTextComponent(nlp, rules='other', rule_list=[item])
+        context = ConTextComponent(nlp, rules="other", rule_list=[item])
         matcher = context.phrase_matcher
         assert matcher(nlp("no evidence of"))
-
 
     def test_is_negated(self):
         doc = nlp("There is no evidence of pneumonia.")
@@ -133,14 +145,16 @@ class TestConTextComponent:
         """Test that a custom spacy attribute which has not been set
         will throw a ValueError.
         """
-        custom_attrs = {'FAKE_MODIFIER': {'non_existent_attribute': True},
-                        }
+        custom_attrs = {
+            "FAKE_MODIFIER": {"non_existent_attribute": True},
+        }
         with pytest.raises(ValueError):
             ConTextComponent(nlp, add_attrs=custom_attrs)
 
     def test_custom_attributes_mapping(self):
-        custom_attrs = {'NEGATED_EXISTENCE': {'is_negated': True},
-                        }
+        custom_attrs = {
+            "NEGATED_EXISTENCE": {"is_negated": True},
+        }
         try:
             Span.set_extension("is_negated", default=False)
         except:
@@ -149,8 +163,9 @@ class TestConTextComponent:
         assert context.context_attributes_mapping == custom_attrs
 
     def test_custom_attributes_value1(self):
-        custom_attrs = {'NEGATED_EXISTENCE': {'is_negated': True},
-                        }
+        custom_attrs = {
+            "NEGATED_EXISTENCE": {"is_negated": True},
+        }
         try:
             Span.set_extension("is_negated", default=False)
         except:
@@ -164,14 +179,17 @@ class TestConTextComponent:
         assert doc.ents[0]._.is_negated is True
 
     def test_custom_attributes_value2(self):
-        custom_attrs = {'FAMILY': {'is_family': True},
-                        }
+        custom_attrs = {
+            "FAMILY": {"is_family": True},
+        }
         try:
             Span.set_extension("is_family", default=False)
         except:
             pass
         context = ConTextComponent(nlp, add_attrs=custom_attrs)
-        context.add([ConTextItem("no evidence of", "DEFINITE_NEGATED_EXISTENCE", "FORWARD")])
+        context.add(
+            [ConTextItem("no evidence of", "DEFINITE_NEGATED_EXISTENCE", "FORWARD")]
+        )
         doc = nlp("There is no evidence of pneumonia.")
         doc.ents = (doc[-2:-1],)
         context(doc)

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -10,11 +10,13 @@ from cycontext.context_graph import overlap_target_modifiers
 
 nlp = spacy.load("en_core_web_sm")
 
-class TestConTextGraph:
 
+class TestConTextGraph:
     def context_graph(self):
         doc = nlp("There is no evidence of pneumonia but there is chf.")
-        item_data1 = ConTextItem("no evidence of", "DEFINITE_NEGATED_EXISTENCE", "forward")
+        item_data1 = ConTextItem(
+            "no evidence of", "DEFINITE_NEGATED_EXISTENCE", "forward"
+        )
         tag_object1 = TagObject(item_data1, 2, 5, doc)
 
         item_data2 = ConTextItem("evidence of", "DEFINITE_EXISTENCE", "forward")
@@ -32,13 +34,13 @@ class TestConTextGraph:
 
     def test_apply_modifiers(self):
         doc, graph = self.context_graph()
-        graph.targets = [doc[5:6]] # "pneumonia"
+        graph.targets = [doc[5:6]]  # "pneumonia"
         graph.apply_modifiers()
         assert len(graph.edges) == 2
 
     def test_prune_modifiers(self):
         doc, graph = self.context_graph()
-        graph.targets = [doc[5:6]] # "pneumonia"
+        graph.targets = [doc[5:6]]  # "pneumonia"
         graph.prune_modifiers()
         assert len(graph.modifiers) == 2
 
@@ -66,11 +68,3 @@ class TestConTextGraph:
         assert overlap_target_modifiers(tag_object.span, doc.ents[0])
         assert len(graph.modifiers) == 0
         assert len(graph.edges) == 0
-
-
-
-
-
-
-
-

--- a/tests/test_context_item.py
+++ b/tests/test_context_item.py
@@ -2,8 +2,8 @@ import pytest
 
 from cycontext import ConTextItem
 
-class TestItemData:
 
+class TestItemData:
     def test_instantiate1(self):
         literal = "no evidence of"
         category = "DEFINITE_NEGATED_EXISTENCE"
@@ -43,12 +43,18 @@ class TestItemData:
         assert item.metadata
 
     def test_from_dict(self):
-        d = dict(literal="reason for examination", category="INDICATION", rule="FORWARD")
+        d = dict(
+            literal="reason for examination", category="INDICATION", rule="FORWARD"
+        )
         assert ConTextItem.from_dict(d)
 
     def test_from_dict_error(self):
-        d = dict(literal="reason for examination", category="INDICATION", rule="FORWARD",
-                 invalid="this is an invalid key")
+        d = dict(
+            literal="reason for examination",
+            category="INDICATION",
+            rule="FORWARD",
+            invalid="this is an invalid key",
+        )
         with pytest.raises(ValueError):
             ConTextItem.from_dict(d)
 
@@ -64,6 +70,7 @@ class TestItemData:
 
     def test_to_json(self):
         import json, os
+
         literal = "no evidence of"
         category = "definite_negated_existence"
         rule = "forward"
@@ -81,10 +88,10 @@ class TestItemData:
         os.remove("test_modifiers.json")
 
 
-
 @pytest.fixture
 def from_json_file():
     import json, os
+
     json_filepath = "test_modifiers.json"
 
     item_data = [
@@ -92,15 +99,13 @@ def from_json_file():
             "literal": "are ruled out",
             "category": "DEFINITE_NEGATED_EXISTENCE",
             "pattern": None,
-            "rule": "backward"
+            "rule": "backward",
         },
         {
             "literal": "is negative",
             "category": "DEFINITE_NEGATED_EXISTENCE",
-            "pattern": [
-                {"LEMMA": "be"}, {"LOWER": "negative"}
-            ],
-            "rule": "backward"
+            "pattern": [{"LEMMA": "be"}, {"LOWER": "negative"}],
+            "rule": "backward",
         },
     ]
 

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -8,8 +8,8 @@ from cycontext.helpers import is_modified_by
 
 nlp = spacy.load("en_core_web_sm")
 
-class TestTagObject:
 
+class TestTagObject:
     def create_objects(self):
         doc = nlp("family history of breast cancer but no diabetes. She has afib.")
         item = ConTextItem("family history of", "FAMILY_HISTORY", rule="FORWARD")
@@ -28,7 +28,7 @@ class TestTagObject:
         spans = [
             Span(doc, 2, 3, "CONDITION"),
             Span(doc, 4, 5, "CONDITION"),
-            Span(doc, 6, 7, "CONDITION")
+            Span(doc, 6, 7, "CONDITION"),
         ]
         doc.ents = spans
         return doc
@@ -67,7 +67,6 @@ class TestTagObject:
         tag_object2 = TagObject(item2, 2, 4, doc)
         assert tag_object.limit_scope(tag_object2)
 
-
     def test_limit_scope2(self):
         doc, item, tag_object = self.create_objects()
         item2 = ConTextItem("but", "TERMINATE", "TERMINATE")
@@ -89,10 +88,18 @@ class TestTagObject:
          """
         doc = nlp("no history of travel to Puerto Rico, neg for pneumonia")
 
-        item = ConTextItem("no history of", "DEFINITE_NEGATED_EXISTENCE", "FORWARD",
-                           allowed_types={"TRAVEL"})
-        item2 = ConTextItem("neg for", "DEFINITE_NEGATED_EXISTENCE", "FORWARD",
-                            allowed_types={"CONDITION"})
+        item = ConTextItem(
+            "no history of",
+            "DEFINITE_NEGATED_EXISTENCE",
+            "FORWARD",
+            allowed_types={"TRAVEL"},
+        )
+        item2 = ConTextItem(
+            "neg for",
+            "DEFINITE_NEGATED_EXISTENCE",
+            "FORWARD",
+            allowed_types={"CONDITION"},
+        )
         tag_object = TagObject(item, 0, 3, doc)
         tag_object2 = TagObject(item2, 8, 10, doc)
         assert not tag_object.limit_scope(tag_object2)
@@ -106,8 +113,10 @@ class TestTagObject:
         with pytest.raises(ValueError) as exception_info:
             # This should fail because doc.sents are None
             TagObject(item, 0, 3, doc)
-        exception_info.match("ConText failed because sentence boundaries have not been set. "
-                             "Add an upstream component such as the dependency parser, Sentencizer, or PyRuSH to detect sentence boundaries.")
+        exception_info.match(
+            "ConText failed because sentence boundaries have not been set. "
+            "Add an upstream component such as the dependency parser, Sentencizer, or PyRuSH to detect sentence boundaries."
+        )
 
     def test_update_scope(self):
         doc, item, tag_object = self.create_objects()
@@ -130,41 +139,44 @@ class TestTagObject:
     def test_allowed_types(self):
         """Test that specifying allowed_types will only modify that target type."""
         doc = self.create_target_type_examples()
-        item = ConTextItem("no history of travel to",
-                           category="DEFINITE_NEGATED_EXISTENCE",
-                           rule="FORWARD",
-                            allowed_types={"TRAVEL"},
-                           )
+        item = ConTextItem(
+            "no history of travel to",
+            category="DEFINITE_NEGATED_EXISTENCE",
+            rule="FORWARD",
+            allowed_types={"TRAVEL"},
+        )
         tag_object = TagObject(item, 0, 5, doc)
         tag_object.set_scope()
-        travel, condition = doc.ents # "puerto rico", "pneumonia"
+        travel, condition = doc.ents  # "puerto rico", "pneumonia"
         assert tag_object.modifies(travel) is True
         assert tag_object.modifies(condition) is False
 
     def test_excluded_types(self):
         """Test that specifying excluded_types will not modify that target type."""
         doc = self.create_target_type_examples()
-        item = ConTextItem("no history of travel to",
-                           category="DEFINITE_NEGATED_EXISTENCE",
-                           rule="FORWARD",
-                            excluded_types={"CONDITION"},
-                           )
+        item = ConTextItem(
+            "no history of travel to",
+            category="DEFINITE_NEGATED_EXISTENCE",
+            rule="FORWARD",
+            excluded_types={"CONDITION"},
+        )
         tag_object = TagObject(item, 0, 5, doc)
         tag_object.set_scope()
-        travel, condition = doc.ents # "puerto rico", "pneumonia"
+        travel, condition = doc.ents  # "puerto rico", "pneumonia"
         assert tag_object.modifies(travel) is True
         assert tag_object.modifies(condition) is False
 
     def test_no_types(self):
         """Test that not specifying allowed_types or excluded_types will modify all targets."""
         doc = self.create_target_type_examples()
-        item = ConTextItem("no history of travel to",
-                           category="DEFINITE_NEGATED_EXISTENCE",
-                           rule="FORWARD"
-                           )
+        item = ConTextItem(
+            "no history of travel to",
+            category="DEFINITE_NEGATED_EXISTENCE",
+            rule="FORWARD",
+        )
         tag_object = TagObject(item, 0, 5, doc)
         tag_object.set_scope()
-        travel, condition = doc.ents # "puerto rico", "pneumonia"
+        travel, condition = doc.ents  # "puerto rico", "pneumonia"
         assert tag_object.modifies(travel) is True
         assert tag_object.modifies(condition) is True
 
@@ -174,8 +186,9 @@ class TestTagObject:
         """
         doc = self.create_num_target_examples()
         assert len(doc.ents) == 3
-        item = ConTextItem("vs", category="UNCERTAIN",
-                           rule="BIDIRECTIONAL", max_targets=2)
+        item = ConTextItem(
+            "vs", category="UNCERTAIN", rule="BIDIRECTIONAL", max_targets=2
+        )
         # Set "vs" to be the modifier
         tag_object = TagObject(item, 5, 6, doc)
         for target in doc.ents:
@@ -193,8 +206,9 @@ class TestTagObject:
         """
         doc = self.create_num_target_examples()
         assert len(doc.ents) == 3
-        item = ConTextItem("vs", category="UNCERTAIN",
-                           rule="BIDIRECTIONAL", max_targets=3)
+        item = ConTextItem(
+            "vs", category="UNCERTAIN", rule="BIDIRECTIONAL", max_targets=3
+        )
         # Set "vs" to be the modifier
         tag_object = TagObject(item, 5, 6, doc)
         for target in doc.ents:
@@ -210,8 +224,9 @@ class TestTagObject:
         """
         doc = self.create_num_target_examples()
         assert len(doc.ents) == 3
-        item = ConTextItem("vs", category="UNCERTAIN",
-                           rule="BIDIRECTIONAL", max_targets=None)
+        item = ConTextItem(
+            "vs", category="UNCERTAIN", rule="BIDIRECTIONAL", max_targets=None
+        )
         # Set "vs" to be the modifier
         tag_object = TagObject(item, 5, 6, doc)
         for target in doc.ents:
@@ -227,8 +242,9 @@ class TestTagObject:
         """
         doc = self.create_num_target_examples()
         assert len(doc.ents) == 3
-        item = ConTextItem("vs", category="UNCERTAIN",
-                           rule="BIDIRECTIONAL", max_scope=1)
+        item = ConTextItem(
+            "vs", category="UNCERTAIN", rule="BIDIRECTIONAL", max_scope=1
+        )
         tag_object = TagObject(item, 5, 6, doc)
 
         for target in doc.ents:
@@ -244,8 +260,9 @@ class TestTagObject:
         """
         doc = self.create_num_target_examples()
         assert len(doc.ents) == 3
-        item = ConTextItem("vs", category="UNCERTAIN",
-                           rule="BIDIRECTIONAL", max_scope=None)
+        item = ConTextItem(
+            "vs", category="UNCERTAIN", rule="BIDIRECTIONAL", max_scope=None
+        )
         tag_object = TagObject(item, 5, 6, doc)
 
         for target in doc.ents:


### PR DESCRIPTION
Updated code formatting using pylint and black coding style.

Most pylint errors are gone, other than a handful that need more extensive refactoring and those that disagree with the black formatting style.

Two classes still need docstrings. All methods have docstrings.