### PR TITLE
Overlapping targets + modifiers

### DIFF
--- a/cycontext/context_graph.py
+++ b/cycontext/context_graph.py
@@ -62,17 +62,6 @@ class ConTextGraph:
         # TODO: Consider only removing modifiers which are subspans.
         """
 
-        # Start by comparing modifiers against targets
-        # Remove any modifiers which overlap with a target
-        # Go backwards so we can remove modifiers which need to be pruned
-        for i in range(len(self.modifiers) - 1, -1, -1):
-            modifier = self.modifiers[i]
-            for target in self.targets:
-                if overlap_target_modifiers(target, modifier.span):
-
-                    self.modifiers.pop(i)
-                    break
-
         unpruned = sorted(self.modifiers, key=lambda x: (x.end - x.end))
         if len(unpruned) > 0:
             rslt = self.prune_overlapping_modifiers(unpruned)

--- a/cycontext/tag_object.py
+++ b/cycontext/tag_object.py
@@ -191,6 +191,12 @@ class TagObject:
 
         target (Span): a spaCy span representing a target concept.
         """
+        # If the target and modifier overlap, meaning at least one token
+        # one extracted as both a target and modifier, return False
+        # to avoid self-modifying concepts
+
+        if self.overlaps_target(target):
+            return False
         if self.rule == "TERMINATE":
             return False
         if not self.allows(target.label_.upper()):
@@ -234,6 +240,15 @@ class TagObject:
             or self.span[-1] in other.span
             or other.span[0] in self.span
             or other.span[-1] in self.span
+        )
+
+    def overlaps_target(self, target):
+        """Returns True if self overlaps with a spaCy span."""
+        return (
+                self.span[0] in target
+                or self.span[-1] in target
+                or target[0] in self.span
+                or target[-1] in self.span
         )
 
     def __gt__(self, other):

--- a/tests/test_tag_object.py
+++ b/tests/test_tag_object.py
@@ -309,3 +309,16 @@ class TestTagObject:
             if tag_object.modifies(target):
                 tag_object.modify(target)
         assert tag_object.num_targets == 3
+
+    def test_overlapping_target(self):
+        """Test that a modifier will not modify a target if it is
+        in the same span as the modifier.
+        """
+        doc = nlp("Pt presents for r/o of pneumonia.")
+        item = ConTextItem(
+            "r/o", "UNCERTAIN", rule="BIDIRECTIONAL"
+        )
+        tag_object = TagObject(item, 3, 4, doc)
+        target = Span(doc, 3, 4, "TEST")
+
+        assert tag_object.modifies(target) is False


### PR DESCRIPTION
Changed overlapping modifiers to not modify the overlapping target rather than be deleted.